### PR TITLE
Make proxy accessible from the external network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,8 @@ services:
       - SSMTP_MAILHUB=mailhog:1025
   proxy:
     image: ledgersmb/ledgersmb-dev-nginx
-    expose:
-      - 80
+    ports:
+      - 80:80
     depends_on:
       - lsmb
     volumes:


### PR DESCRIPTION
The proxy is the only accessible point to the application, it must be on the external network instead of exposing to the internal only.